### PR TITLE
Fix syntax for process optional flag

### DIFF
--- a/lib/worker.nf
+++ b/lib/worker.nf
@@ -55,8 +55,8 @@ process worker {
 
     // Modules have the option of producing additional files in plots/ and qc/
     //   subdirectories. These are captured and published to the project directory.
-    path('plots/**') optional true
-    path('qc/**') optional true
+    path('plots/**'), optional: true
+    path('qc/**'), optional: true
 
     // Provenance
     tuple path('.command.sh'), path('.command.log')

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -28,7 +28,7 @@ process s3seg {
       tuple val(tag), path("*/*.ome.tif"), emit: segmasks
 
       // qc and provenance
-      path('*/qc/**') optional true
+      path('*/qc/**'), optional: true
       tuple path('.command.sh'), path('.command.log')
 
     when: Flow.doirun('watershed', mcp.workflow)

--- a/modules/viz.nf
+++ b/modules/viz.nf
@@ -20,7 +20,7 @@ process autominerva {
     path("${tag}/**"), emit: viz
 
     // qc and provenance
-    path('*/qc/**') optional true
+    path('*/qc/**'), optional: true
     tuple path('.command.sh'), path('.command.log')
 
   when: Flow.doirun('viz', wfp)


### PR DESCRIPTION
The workflow code parser in Nextflow 25.10.0 seems to have gotten stricter, requiring these changes in our code.