### PR TITLE
Updated Backsub and docs

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -20,6 +20,7 @@ options:
   ilastik: --num_channels 1
   mcquant: --masks cell*.tif *_cp_masks*.tif
   naivestates: -p png
+  backsub: --compression zlib
   imagej-rolling-ball: 100 -n=4 -j="-Xmx4g"
 modules:
   illumination:

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -49,11 +49,11 @@ modules:
     -
       name: backsub
       container: ghcr.io/schapirolabor/background_subtraction
-      version: v0.4.1
+      version: v0.5.1
       cmd: |-
-        python3 /background_subtraction/background_sub.py \
-          -r ${image} -m ${marker} \
-          -o ${image_id}_backsub.ome.tif -mo markers_bs.csv
+        backsub \
+          --input ${image} --markers ${marker} \
+          --output "${image_id}_backsub.ome.tif" --marker-output markers_bs.csv
     -
       name: imagej-rolling-ball
       container: yuanchen12/imagej-rolling-ball

--- a/docs/parameters/core.md
+++ b/docs/parameters/core.md
@@ -845,7 +845,7 @@ workflow:
 | --- | --- | --- |
 | `--pixel-size` | `None` | The resolution of the image in microns-per-pixel. If not provided, it is read from metadata. If that is not possible, 1 is assigned. |
 | `--tile-size` | `256` | Tile size used for pyramid image generation.|
-| `--compression` | `lzw` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
+| `--compression` | `zlib` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
 
 [Back to Other Modules](./core.html#other-modules){: .btn .btn-purple} [Back to top](./core){: .btn .btn-outline} 
 

--- a/docs/parameters/core.md
+++ b/docs/parameters/core.md
@@ -836,7 +836,7 @@ workflow:
 
 ### Outputs
 
-* A pyramidal, tiled `.ome.tif`. Nextflow will write the output file to `background/` within the project directory.
+* A pyramidal, tiled `.ome.tif`. Nextflow will write the output file to `background/` within the project directory. By default, the output is compressed.
 * A modified `markers.csv` to match the background subtracted image.
 
 ### Optional arguments
@@ -844,8 +844,8 @@ workflow:
 | Parameter | Default | Description |
 | --- | --- | --- |
 | `--pixel-size` | `None` | The resolution of the image in microns-per-pixel. If not provided, it is read from metadata. If that is not possible, 1 is assigned. |
-| `--tile-size` | `1024` | Tile size used for pyramid image generation.|
-| `--chunk-size` | `5000` | Chunk size used for lazy loading and processing the image.|
+| `--tile-size` | `256` | Tile size used for pyramid image generation.|
+| `--compression` | `lzw` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
 
 [Back to Other Modules](./core.html#other-modules){: .btn .btn-purple} [Back to top](./core){: .btn .btn-outline} 
 

--- a/docs/parameters/other.md
+++ b/docs/parameters/other.md
@@ -374,7 +374,7 @@ Nextflow will write all outputs to the `cell-states/naivestates/` subdirectory w
 
 ### Usage
 By default, MCMICRO assumes background subtraction should not be performed. Add `background: true` to [module options]({{site.baseurl}}/parameters/workflow.html#background) to indicate it should be. By default, the `background-method` parameter is set to `backsub`. 
-If channels are removed using this module, and `segmentation-channel` is specified, it should be kept in mind that the index provided with `segmentation-channel` would refer to the index after channel removal.
+If channels are removed using this module, and `segmentation-channel` is specified, it should be kept in mind that the index provided with `segmentation-channel` would refer to the index after channel removal. Note that if the corrected outputs are compressed, and a segmentation method fails, `segmentation-recyze` should be used to get around the issue.
 
 * Example `params.yml`:
 
@@ -393,7 +393,7 @@ workflow:
 
 ### Outputs
 
-* A pyramidal, tiled `.ome.tif`. Nextflow will write the output file to `background/` within the project directory.
+* A pyramidal, tiled `.ome.tif`. Nextflow will write the output file to `background/` within the project directory. By default, the output is compressed.
 * A modified `markers.csv` to match the background subtracted image.
 
 ### Optional arguments
@@ -401,7 +401,7 @@ workflow:
 | Parameter | Default | Description |
 | --- | --- | --- |
 | `--pixel-size` | `None` | The resolution of the image in microns-per-pixel. If not provided, it is read from metadata. If that is not possible, 1 is assigned. |
-| `--tile-size` | `1024` | Tile size used for pyramid image generation.|
-| `--chunk-size` | `5000` | Chunk size used for lazy loading and processing the image.|
+| `--tile-size` | `256` | Tile size used for pyramid image generation.|
+| `--compression` | `lzw` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
 
 [Back to Other Modules](./core.html#other-modules){: .btn .btn-purple} [Back to top](./core){: .btn .btn-outline} 

--- a/docs/parameters/other.md
+++ b/docs/parameters/other.md
@@ -402,6 +402,6 @@ workflow:
 | --- | --- | --- |
 | `--pixel-size` | `None` | The resolution of the image in microns-per-pixel. If not provided, it is read from metadata. If that is not possible, 1 is assigned. |
 | `--tile-size` | `256` | Tile size used for pyramid image generation.|
-| `--compression` | `lzw` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
+| `--compression` | `zlib` | The output pyramidal OME-TIFF will be compressed using the specified compression. Set to "none" for no compression. "lzw", "zlib", or "none" are accepted options. |
 
 [Back to Other Modules](./core.html#other-modules){: .btn .btn-purple} [Back to top](./core){: .btn .btn-outline} 


### PR DESCRIPTION
Hi,

We've recently pushed an updated Backsub version 0.5.1 that is more lightweight, as efficient, and allows for compression of autofluorescence-subtracted pyramidal OME-TIFFs (by default with `lzw`). I've updated the docs accordingly. 

Compression can be toggled off by setting `--compression none` if users do not want that functionality.

Introducing the compression, from our testing, only affects running Mesmer (which in the provided container) doesn't have imagecodecs. Using Recyze is anyway recommended when using it which mitigates the potential conflict.

Backsub now throws an error if the background does not match any marker_name value, and a warning if the background column is empty.

If the background value appears multiple times in the marker_name column (even with the strong recommentation to have unique values in the marker_name column), only the first value is used as the respective background. Closes [#559](https://github.com/labsyspharm/mcmicro/issues/559)

I think this PR should close [#570](https://github.com/labsyspharm/mcmicro/issues/570) because the issue mentioned has no possibility to appear with the updated version.